### PR TITLE
fix: humidifiers level 0 handling

### DIFF
--- a/custom_components/venta/const.py
+++ b/custom_components/venta/const.py
@@ -11,6 +11,7 @@ AUTO_API_VERSION = "auto"
 DEFAULT_SCAN_INTERVAL = 10
 NO_WATER_THRESHOLD = 50000
 
+MODE_LEVEL_0 = "level_0"
 MODE_LEVEL_1 = "level_1"
 MODE_LEVEL_2 = "level_2"
 MODE_LEVEL_3 = "level_3"
@@ -19,6 +20,7 @@ MODE_LEVEL_5 = "level_5"
 
 MODES_3: list[str] = [
     MODE_AUTO,
+    MODE_LEVEL_0,
     MODE_LEVEL_1,
     MODE_LEVEL_2,
     MODE_LEVEL_3,

--- a/custom_components/venta/strings.json
+++ b/custom_components/venta/strings.json
@@ -47,6 +47,7 @@
               "sleep": "Sleep",
               "auto": "Auto",
               "boost": "Boost",
+              "level_0": "None",
               "level_1": "Level 1",
               "level_2": "Level 2",
               "level_3": "Level 3",

--- a/custom_components/venta/venta_entity.py
+++ b/custom_components/venta/venta_entity.py
@@ -127,7 +127,7 @@ class VentaBaseHumidifierEntity(
             return MODE_AUTO
         if MODE_SLEEP in self._attr_available_modes and data.action.get("SleepMode"):
             return MODE_SLEEP
-        level = data.action.get("FanSpeed", 1)
+        level = data.action.get("FanSpeed", 0)
         return f"level_{level}"
 
     @property


### PR DESCRIPTION
This can occure if fan is disabled due to missing watter and no other mode is enabled. 