### PR TITLE
fix: writer close if connection does not open for tcp strategy 

### DIFF
--- a/custom_components/venta/venta_strategy.py
+++ b/custom_components/venta/venta_strategy.py
@@ -153,6 +153,8 @@ class VentaTcpStrategy(VentaProtocolStrategy):
 
     async def _send_request(self, message: str) -> dict[str, Any] | None:
         """Request data from the Venta device using TCP protocol."""
+        writer = None
+
         try:
             reader, writer = await asyncio.open_connection(
                 self._host_definition.host, self._host_definition.port


### PR DESCRIPTION
If the asyncio.open_connection call fails, writer will never be assigned a value, which means the comparison in the finally block will throw an UnboundLocalError. We work around this by just assigning None to writer at the outset

This fixes the secondary exception in #79 but not the main problem